### PR TITLE
Use provider & consumer to manage the random words and favorite state

### DIFF
--- a/lib/FavoritesPage.dart
+++ b/lib/FavoritesPage.dart
@@ -1,16 +1,10 @@
 import 'package:english_words/english_words.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:namer_app/main.dart';
+import 'package:provider/provider.dart';
 
 class FavoritesPage extends StatefulWidget {
-  const FavoritesPage({
-    super.key,
-    required this.favorites,
-    required this.removeFavorite,
-  });
-
-  final void Function(WordPair) removeFavorite;
-  final List<WordPair> favorites;
+  const FavoritesPage({super.key});
 
   @override
   State<FavoritesPage> createState() => _FavoritesPageState();
@@ -21,30 +15,32 @@ class _FavoritesPageState extends State<FavoritesPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.only(top: 8.0, left: 16.0),
-          child: Text("You have ${widget.favorites.length} favorites"),
-        ),
-        Expanded(
-          child: AnimatedList(
-            key: _listKey,
-            initialItemCount: widget.favorites.length,
-            itemBuilder: (context, index, animation) {
-              final word = widget.favorites[index];
-              return _buildItem(
-                index,
-                word,
-                animation,
-                () => _removeItem(index, word),
-              );
-            },
-          ),
-        ),
-      ],
-    );
+    return Consumer<RandomWordsProvider>(
+        builder: (context, provider, child) => Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0, left: 16.0),
+                  child:
+                      Text("You have ${provider.favorites.length} favorites"),
+                ),
+                Expanded(
+                  child: AnimatedList(
+                    key: _listKey,
+                    initialItemCount: provider.favorites.length,
+                    itemBuilder: (context, index, animation) {
+                      final word = provider.favorites[index];
+                      return _buildItem(
+                        index,
+                        word,
+                        animation,
+                        () => _removeItem(index, word, provider.removeFavorite),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ));
   }
 
   Widget _buildItem(int index, WordPair word, Animation<double> animation,
@@ -60,8 +56,12 @@ class _FavoritesPageState extends State<FavoritesPage> {
         ),
       );
 
-  void _removeItem(int index, WordPair word) {
-    widget.removeFavorite(word);
+  void _removeItem(
+    int index,
+    WordPair word,
+    Function(WordPair) removeFavorite,
+  ) {
+    removeFavorite(word);
     _listKey.currentState?.removeItem(
       index,
       (context, animation) => _buildItem(index, word, animation, null),

--- a/lib/GeneratorPage.dart
+++ b/lib/GeneratorPage.dart
@@ -1,23 +1,11 @@
 import 'package:english_words/english_words.dart';
 import 'package:flutter/material.dart';
 import 'package:namer_app/HistoryListView.dart';
+import 'package:namer_app/main.dart';
+import 'package:provider/provider.dart';
 
 class GeneratorPage extends StatefulWidget {
-  const GeneratorPage(
-      {super.key,
-      required this.pair,
-      required this.getNextWord,
-      required this.toggleFavorites,
-      required this.isFavorite,
-      required this.favorites,
-      required this.history});
-
-  final List<WordPair> history;
-  final WordPair pair;
-  final void Function(AnimatedListState?) getNextWord;
-  final VoidCallback toggleFavorites;
-  final List<WordPair> favorites;
-  final bool Function(WordPair) isFavorite;
+  const GeneratorPage({super.key});
 
   @override
   State<GeneratorPage> createState() => _GeneratorPageState();
@@ -28,46 +16,50 @@ class _GeneratorPageState extends State<GeneratorPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Expanded(
-          flex: 3,
-          child: HistoryListView(
-            history: widget.history,
-            isFavorite: widget.isFavorite,
-            listKey: listKey,
-          ),
-        ),
-        const Text("A random idea:"),
-        WordCard(pair: widget.pair),
-        const SizedBox(height: 10),
-        Center(
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              FavoriteButton(
-                pair: widget.pair,
-                isFavorite: widget.isFavorite,
-                toggleFavorites: () {
-                  widget.toggleFavorites();
-                },
-              ),
-              const SizedBox(width: 20),
-              ElevatedButton(
-                  onPressed: () {
-                    widget.getNextWord(listKey.currentState);
-                  },
-                  child: const Text("Next")),
-            ],
-          ),
-        ),
-        const Expanded(
-          flex: 2,
-          child: SizedBox(),
-        )
-      ],
-    );
+    return Consumer<RandomWordsProvider>(
+        builder: (context, provider, child) => Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Expanded(
+                  flex: 3,
+                  child: HistoryListView(
+                    history: provider.history,
+                    isFavorite: (wordpair) =>
+                        provider.favorites.contains(wordpair),
+                    listKey: listKey,
+                  ),
+                ),
+                const Text("A random idea:"),
+                WordCard(pair: provider.current),
+                const SizedBox(height: 10),
+                Center(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      FavoriteButton(
+                        pair: provider.current,
+                        isFavorite: (wordpair) =>
+                            provider.favorites.contains(wordpair),
+                        toggleFavorites: () {
+                          provider.toggleFavorites();
+                        },
+                      ),
+                      const SizedBox(width: 20),
+                      Consumer<RandomWordsProvider>(
+                          builder: (context, provider, child) => ElevatedButton(
+                              onPressed: () {
+                                provider.getNext(listKey.currentState);
+                              },
+                              child: const Text("Next"))),
+                    ],
+                  ),
+                ),
+                const Expanded(
+                  flex: 2,
+                  child: SizedBox(),
+                )
+              ],
+            ));
   }
 }
 

--- a/lib/GeneratorPage.dart
+++ b/lib/GeneratorPage.dart
@@ -45,12 +45,11 @@ class _GeneratorPageState extends State<GeneratorPage> {
                         },
                       ),
                       const SizedBox(width: 20),
-                      Consumer<RandomWordsProvider>(
-                          builder: (context, provider, child) => ElevatedButton(
-                              onPressed: () {
-                                provider.getNext(listKey.currentState);
-                              },
-                              child: const Text("Next"))),
+                      ElevatedButton(
+                          onPressed: () {
+                            provider.getNext(listKey.currentState);
+                          },
+                          child: const Text("Next")),
                     ],
                   ),
                 ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-        create: (context) => MyAppState(),
+        create: (context) => RandomWordsProvider(),
         child: MaterialApp(
           title: "Namer App",
           theme: ThemeData(
@@ -28,9 +28,9 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyAppState extends ChangeNotifier {
+class RandomWordsProvider extends ChangeNotifier {
   var current = WordPair.random();
-  var favorites = <WordPair>{};
+  var favorites = <WordPair>[];
   var history = <WordPair>[];
 
   void toggleFavorites() {
@@ -43,8 +43,8 @@ class MyAppState extends ChangeNotifier {
   }
 
   void removeFavorite(WordPair word) {
-      favorites.remove(word);
-      notifyListeners();
+    favorites.remove(word);
+    notifyListeners();
   }
 
   void getNext(AnimatedListState? state) {
@@ -67,37 +67,13 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    var appState = context.watch<MyAppState>();
-    var pair = appState.current;
-    if (kDebugMode) {
-      print("Favorites: ${appState.favorites.length} ❤️❤️❤️");
-    }
-
     Widget page;
     switch (selectedIndex) {
       case 0:
-        page = GeneratorPage(
-          pair: pair,
-          favorites: appState.favorites.toList(),
-          history: appState.history,
-          getNextWord: (AnimatedListState? state) {
-            appState.getNext(state);
-          },
-          toggleFavorites: () {
-            appState.toggleFavorites();
-          },
-          isFavorite: (WordPair pair) {
-            return appState.favorites.contains(pair);
-          },
-        );
+        page = const GeneratorPage();
         break;
       case 1:
-        page = FavoritesPage(
-          favorites: appState.favorites.toList(),
-          removeFavorite: (WordPair word) {
-            appState.removeFavorite(word);
-          },
-        );
+        page = const FavoritesPage();
         break;
       default:
         throw UnimplementedError('no widget for $selectedIndex');


### PR DESCRIPTION
Even though the initial implementation also used `Provider`, it is a vanilla version where the widget must watch for changes in the AppState.

This implementation wraps the widget with a `Consumer` and allows the widget to directly access the provider's properties or methods.

```dart
Consumer<RandomWordProvider>(
    builder: (context, provider, child) => widget
)
```