### PR TITLE
Demo of State Management using BloC

### DIFF
--- a/lib/HistoryListView.dart
+++ b/lib/HistoryListView.dart
@@ -1,16 +1,29 @@
-import 'package:english_words/english_words.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:namer_app/model/random_word/RandomWord.dart';
+import 'package:namer_app/random_word/bloc.dart';
+import 'package:namer_app/random_word/event.dart';
+import 'package:namer_app/random_word/state.dart';
 
+/// A widget that displays a list of previously generated words.
+///
+/// This widget is used to display a list of previously generated [RandomWordState.history] that
+/// the user has seen. It is an animated list that is displayed on the top
+/// of the screen and is updated every time a new word is generated. The user
+/// can tap on a word in the list to toggle its favorite state, which triggers [RandomWordEvent.ToggleFavorite].
+///
+/// The [history] is a list of previously generated [Word] objects.
+/// The [listKey] is a [GlobalKey] object used to control the state
+/// of the animated list, e.g., inserting a new word to the bottom.
+///
 class HistoryListView extends StatefulWidget {
   const HistoryListView({
     super.key,
     required this.history,
-    required this.isFavorite,
     required this.listKey,
   });
 
-  final List<WordPair> history;
-  final bool Function(WordPair) isFavorite;
+  final List<Word> history;
   final GlobalKey<AnimatedListState> listKey;
 
   @override
@@ -18,7 +31,6 @@ class HistoryListView extends StatefulWidget {
 }
 
 class _HistoryListViewState extends State<HistoryListView> {
-
   static const Gradient _maskingGradient = LinearGradient(
       colors: [Colors.transparent, Colors.black],
       stops: [0.0, 0.5],
@@ -35,16 +47,18 @@ class _HistoryListViewState extends State<HistoryListView> {
           reverse: true,
           initialItemCount: widget.history.length,
           itemBuilder: (context, index, animation) {
-            final pair = widget.history[index];
+            final word = widget.history[index];
             return SizeTransition(
               sizeFactor: animation,
               child: Center(
                 child: TextButton.icon(
-                  onPressed: () {},
-                  icon: widget.isFavorite(pair)
+                  onPressed: () {
+                    context.read<RandomWordBloc>().add(ToggleFavorite(word));
+                  },
+                  icon: word.isFavorite
                       ? const Icon(Icons.favorite, size: 12)
                       : const SizedBox(),
-                  label: Text(pair.asLowerCase),
+                  label: Text(word.text.asLowerCase),
                 ),
               ),
             );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,26 @@
 import 'package:english_words/english_words.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:namer_app/FavoritesPage.dart';
+import 'package:namer_app/random_word/bloc.dart';
 import 'package:provider/provider.dart';
 
 import 'GeneratorPage.dart';
 
 void main() {
   runApp(const MyApp());
+  Bloc.observer = SimpleBlocObserver();
+}
+
+class SimpleBlocObserver extends BlocObserver {
+  @override
+  void onChange(BlocBase bloc, Change change) {
+    super.onChange(bloc, change);
+    if (kDebugMode) {
+      print('😀😀😀 ${bloc.runtimeType} $change');
+    }
+  }
 }
 
 class MyApp extends StatelessWidget {
@@ -16,42 +29,15 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-        create: (context) => RandomWordsProvider(),
+    return BlocProvider(
+        create: (_) => RandomWordBloc(),
         child: MaterialApp(
           title: "Namer App",
           theme: ThemeData(
               useMaterial3: true,
               colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepOrange)),
-          home: MyHomePage(),
+          home: const MyHomePage(),
         ));
-  }
-}
-
-class RandomWordsProvider extends ChangeNotifier {
-  var current = WordPair.random();
-  var favorites = <WordPair>[];
-  var history = <WordPair>[];
-
-  void toggleFavorites() {
-    if (favorites.contains(current)) {
-      favorites.remove(current);
-    } else {
-      favorites.add(current);
-    }
-    notifyListeners();
-  }
-
-  void removeFavorite(WordPair word) {
-    favorites.remove(word);
-    notifyListeners();
-  }
-
-  void getNext(AnimatedListState? state) {
-    current = WordPair.random();
-    history.insert(0, current);
-    state?.insertItem(0);
-    notifyListeners();
   }
 }
 

--- a/lib/model/random_word/RandomWord.dart
+++ b/lib/model/random_word/RandomWord.dart
@@ -1,0 +1,25 @@
+import 'package:english_words/english_words.dart';
+import 'package:equatable/equatable.dart';
+
+class Word extends Equatable {
+  final WordPair text;
+  final bool isFavorite;
+
+  const Word({
+    required this.text,
+    required this.isFavorite,
+  });
+
+  @override
+  List<Object?> get props => [text, isFavorite];
+
+  Word copyWith({WordPair? text, bool? isFavorite}) {
+    return Word(
+      text: text ?? this.text,
+      isFavorite: isFavorite ?? this.isFavorite,
+    );
+  }
+
+  static Word createInstance() =>
+      Word(text: WordPair.random(), isFavorite: false);
+}

--- a/lib/random_word/bloc.dart
+++ b/lib/random_word/bloc.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../model/random_word/RandomWord.dart';
+import 'event.dart';
+import 'state.dart';
+
+class RandomWordBloc extends Bloc<RandomWordEvent, RandomWordState> {
+  final List<Word> _history = <Word>[];
+  late Word _current;
+
+  RandomWordBloc()
+      : super(HistoryUpdated(List.empty(), Word.createInstance())) {
+    on<GetNewWord>(_getNewWord);
+    on<ToggleFavorite>(_toggleFavorite);
+    on<RemoveFavorite>(_removeFavorite);
+    _current = state.current;
+  }
+
+  /// Respond to events
+  void _getNewWord(GetNewWord event, Emitter<RandomWordState> emit) async {
+    _history.insert(0, _current);
+    _current = Word.createInstance();
+    emit(HistoryUpdated(_history, _current));
+  }
+
+  void _toggleFavorite(ToggleFavorite event, Emitter<RandomWordState> emit) {
+    _updateFavorite(event.word, emit);
+  }
+
+  void _removeFavorite(RemoveFavorite event, Emitter<RandomWordState> emit) {
+    _updateFavorite(event.word, emit, shouldRemoveFavorite: true);
+  }
+
+  /// Helper
+  void _updateFavorite(
+    Word word,
+    Emitter<RandomWordState> emit, {
+    bool shouldRemoveFavorite = false,
+  }) {
+    if (word.text == _current.text) {
+      _updateFavoriteOfCurrentWord(shouldRemoveFavorite);
+    } else {
+      _updateFavoriteOfHistoryWord(word, shouldRemoveFavorite);
+    }
+    emit(HistoryUpdated(_history, _current));
+  }
+
+  void _updateFavoriteOfHistoryWord(Word word, bool shouldRemoveFavorite) {
+    final index = _history.indexWhere((item) => item.text == word.text);
+    _history[index] = _history[index].copyWith(
+        isFavorite: shouldRemoveFavorite ? false : !_history[index].isFavorite);
+  }
+
+  void _updateFavoriteOfCurrentWord(bool shouldRemoveFavorite) {
+    _current = _current.copyWith(
+        isFavorite: shouldRemoveFavorite ? false : !_current.isFavorite);
+  }
+}

--- a/lib/random_word/event.dart
+++ b/lib/random_word/event.dart
@@ -1,0 +1,20 @@
+import '../model/random_word/RandomWord.dart';
+
+abstract class RandomWordEvent {}
+
+/// Create a new random word.
+class GetNewWord extends RandomWordEvent {}
+
+/// Toggle the favorite of the given word.
+class ToggleFavorite extends RandomWordEvent {
+  ToggleFavorite(this.word);
+
+  final Word word;
+}
+
+/// Undo the favorite of the given word.
+class RemoveFavorite extends RandomWordEvent {
+  RemoveFavorite(this.word);
+
+  final Word word;
+}

--- a/lib/random_word/state.dart
+++ b/lib/random_word/state.dart
@@ -1,0 +1,47 @@
+import 'package:equatable/equatable.dart';
+
+import '../model/random_word/RandomWord.dart';
+
+/// This abstract class defines the state of a Bloc which generates random words
+/// and stores them in [history]. It provides a list of [favorites] words based on the
+/// [current] and historical state of generated words.
+abstract class RandomWordState extends Equatable {
+  /// Creates a new [RandomWordState] with the given `history` and `current`.
+  ///
+  /// The [history] parameter represents the list of generated words stored in history.
+  ///
+  /// The [current] parameter represents the current word being displayed.
+  const RandomWordState(this.history, this.current);
+
+  /// The list of generated words stored in history.
+  final List<Word> history;
+
+  /// The current word being displayed.
+  final Word current;
+
+  /// Returns a list of favorite words based on the current and historical state of generated words.
+  ///
+  /// If the current word is a favorite, it is included in the returned list. Otherwise,
+  /// only the historical favorite words are returned.
+  List<Word> get favorites {
+    if (current.isFavorite) {
+      return [...history.where((word) => word.isFavorite), current];
+    } else {
+      return history.where((word) => word.isFavorite).toList();
+    }
+  }
+
+  @override
+  List<Object?> get props => [history, current, favorites];
+}
+
+/// This class represents the state of the Bloc when the [history] is updated
+/// with a new word, or the [Word.isFavorite] state changes.
+class HistoryUpdated extends RandomWordState {
+  const HistoryUpdated(List<Word> history, Word current)
+      : super(history, current);
+
+  @override
+  String toString() =>
+      "[$runtimeType] Number of random words generated: ${history.length}";
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
 
   english_words: ^4.0.0
   provider: ^6.0.0
+  flutter_bloc: ^8.1.2
+  equatable: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Context

Demonstrate the state management using BloC

## TODO
- Remove the `Provider` from the Namer app
- Add `RandomWordBloc` and its associated states and events
- Refactor `GeneratorPage` and `FavoritePage` with `BlocBuilder` 
- Triggers events when the user tries generate a new word or toggle the favorite of a word