### PR TITLE
Typo of the keystore name, which results in CodeMagic build failure

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -26,7 +26,7 @@ workflows:
       - bundle exec fastlane setup_keychain
       - |
         # set up release keystore & key.properties
-        echo $ANDROID_KEYSTORE | base64 --decode > "$FCI_BUILD_DIR/android/app/itc-release.keystore"
+        echo $ANDROID_KEYSTORE | base64 --decode > "$FCI_BUILD_DIR/android/app/randomword-release.keystore"
         echo $ANDROID_KEY_PROPERTIES | base64 --decode > "$FCI_BUILD_DIR/android/key.properties"
       - |
         # set up local properties


### PR DESCRIPTION
Error message: 
```yaml
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:validateSigningRelease'.
> Keystore file '/Users/builder/clone/android/app/randomword-release.keystore' not found for signing config 'release'.
```