### PR TITLE
Increment version name and version code to test in the CodeMagic

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # For more information, check out Version your app in the Android documentation.
 # Override: BUILD_NUMBER=[#] bundle exec fastlane android deploy
 # https://blog.codemagic.io/ci-cd-for-flutter-with-fastlane-codemagic/#first-upload
-version: 0.0.1+2
+version: 0.0.2+3
 
 environment:
   sdk: '>=2.19.4 <4.0.0'


### PR DESCRIPTION
# Context
App Store Connect and Google Play requires the bump of version name and version code for each build upload. 
We are testing the publish workflow in the CodeMagic, and each attempt should bump the version accordingly. 

# Comments
In the future, we will try to have CodeMagic to increment the build automatically. 
