### PR TITLE
Fix the error of failing to find profile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -77,9 +77,7 @@ fastlane renew_profile
       sh("flutter", "build", "ios", "--release", "--no-codesign")
     end
 
-    # first remove old and expired provisioning profiles (workaround: https://github.com/fastlane/fastlane/issues/3738)
-    remove_old_profiles
-    match(app_identifier: 'com.ripplearc.composerandomwords', type: 'appstore', keychain_password: 'secretPass', readonly: RUNNING_ON_CI)
+    refresh_appstore_profiles
 
     build_app(
       scheme: "Runner",

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -2,7 +2,7 @@ git_url(ENV['TOD_MATCH_REPO'].to_s)
 
 storage_mode("git")
 
-type("development") # The default type, can be: appstore, adhoc, enterprise or development
+type("appstore") # The default type, can be: appstore, adhoc, enterprise or development
 
 app_identifier(["com.ripplearc.composerandomwords"])
 


### PR DESCRIPTION
# Context
Here is the error when running fastlane with the command: 
```yaml
 # first remove old and expired provisioning profiles (workaround: https://github.com/fastlane/fastlane/issues/3738)
    remove_old_profiles
    match(app_identifier: 'com.ripplearc.composerandomwords', type: 'appstore', keychain_password: 'secretPass', readonly: RUNNING_ON_CI)
```
Error
> No profiles for 'com.ripplearc.composerandomwords' were found: Xcode couldn't find any iOS App Development provisioning profiles matching 'com.ripplearc.composerandomwords'.

# Task
- It seems that calling `refresh_appstore_profiles` lane do the magic?
- Push to the CodeMagic workflow to rerun