### PR TITLE
Change the Xcode project automatic signing to manual

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -77,7 +77,7 @@ fastlane renew_profile
       sh("flutter", "build", "ios", "--release", "--no-codesign")
     end
 
-    refresh_appstore_profiles
+    match(app_identifier: 'com.ripplearc.composerandomwords', type: 'appstore', keychain_password: 'secretPass', readonly: RUNNING_ON_CI)
 
     build_app(
       scheme: "Runner",

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -356,8 +356,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = K2CZ7Y95MG;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = K2CZ7Y95MG;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -366,6 +369,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ripplearc.composerandomwords;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.ripplearc.composerandomwords";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -485,8 +490,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = K2CZ7Y95MG;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = K2CZ7Y95MG;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -495,6 +503,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ripplearc.composerandomwords;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.ripplearc.composerandomwords";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -508,8 +518,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = K2CZ7Y95MG;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = K2CZ7Y95MG;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -518,6 +531,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ripplearc.composerandomwords;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.ripplearc.composerandomwords";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
# Context

We have been plagued by the infamous error message in the CodeMagic for a few days: 

```
Runner.xcodeproj: error: No profiles for 'com.ripplearc.composerandomwords' were found: Xcode couldn't find any iOS App Development provisioning profiles matching 'com.ripplearc.composerandomwords'
```

The tricky thing is we should have used iOS App `Distribution` provision instead of the the `Development` provision. At the beginning we attempted to solve the problem by messing around with the `match` command but in vain. 

The more we looked at the error message, the more apparent it is the `Runner.xcodeproj` that is looking for the `Development Provisioning`. By asking it to look for `match AppStore com.ripplearc.composerandomwords`, it seems to solve the problem for CodeMagic.