### PR TITLE
Bump the iOS build version automatically in CodeMagic

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -20,10 +20,20 @@ workflows:
           include: true
           source: false
     scripts:
-      - bundle install
-      - bundle exec fastlane setup_keychain
-      - find . -name "Podfile" -execdir pod install \;
-      - sh ci/build_ios_qa.sh
+      - name: Set the build version
+        script: |
+          #!/bin/sh
+          set -e
+          set -x
+          cd $CM_BUILD_DIR/ios
+          agvtool new-version -all $(($BUILD_NUMBER + 1))
+          cd $CM_BUILD_DIR
+      - name: Build iOS app
+        script: |
+          bundle install
+          bundle exec fastlane setup_keychain
+          find . -name "Podfile" -execdir pod install \;
+          sh ci/build_ios_qa.sh
     artifacts:
       - build/ios/ipa/*.ipa
       - ./*.ipa

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,3 +1,5 @@
+# Tutorial: CI/CD for Flutter is a piece of cake with fastlane and Codemagic
+# https://blog.codemagic.io/ci-cd-for-flutter-with-fastlane-codemagic/
 default_platform(:ios)
 
 RUNNING_ON_CI = ENV['CI'].to_s.downcase == 'true'


### PR DESCRIPTION
# Context

iOS versioning relies on two essential values: CFBundleShortVersionString (Release Version Number) and CFBundleVersion (Build Version Number). CFBundleShortVersionString represents the user-facing release version displayed in the App Store, while CFBundleVersion is used for internal testing and development purposes. Increment CFBundleShortVersionString for each release on the App Store, and update CFBundleVersion for every TestFlight release candidate. It is recommended to automate versioning using CI/CD pipelines for iOS app builds and submissions.

# Tasks
This is a simple solution without consulting with App Store Center for the latest version number:

```yaml
scripts:
    - name: Set the build version
      script: | 
        #!/bin/sh
        set -e
        set -x
        cd $CM_BUILD_DIR
        agvtool new-version -all $(($BUILD_NUMBER + 1))
```

`BUILD_NUMBER` Holds the total count of builds (including the ongoing build) for a specific workflow in Codemagic. In other words, if you have triggered 10 builds for some workflow in Codemagic, the next time you build it, `BUILD_NUMBER` will be exported as 11.