### PR TITLE
Use BUILD_NUMBER to auto increase the Flutter Build Number

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -20,14 +20,6 @@ workflows:
           include: true
           source: false
     scripts:
-      - name: Set the build version
-        script: |
-          #!/bin/sh
-          set -e
-          set -x
-          cd $CM_BUILD_DIR/ios
-          agvtool new-version -all $(($BUILD_NUMBER + 1))
-          cd $CM_BUILD_DIR
       - name: Build iOS app
         script: |
           bundle install
@@ -48,6 +40,7 @@ workflows:
     max_build_duration: 60
     environment:
       groups:
+        - match
         - app_store
         - google_play
         - keystore_credentials

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,9 +74,10 @@ fastlane renew_profile
 
   desc 'Builds an appstore version of the application and distributes to AppStore Connect'
   lane :deploy do
+    BUILD_NUMBER = ENV['BUILD_NUMBER'].to_s
     common_build_actions()
     Dir.chdir ".." do
-      sh("flutter", "build", "ios", "--release", "--no-codesign")
+      sh("flutter", "build", "ios", "--release", "--no-codesign", "--build-number=#{BUILD_NUMBER}")
     end
 
     match(app_identifier: 'com.ripplearc.composerandomwords', type: 'appstore', keychain_password: 'secretPass', readonly: RUNNING_ON_CI)


### PR DESCRIPTION
# Context
Flutter generalizes iOS and Android build versioning with the [pubspec.yaml version property](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/templates/app/pubspec.yaml.tmpl#L9-L19). This is a value in the form `{major}.{minor}.{patch}+{build_number}` (e.g. 1.2.3+45). 

In Flutter builds, the value for build name, `{major}.{minor}.{patch}`, sets `CFBundleShortVersionString` for iOS and `versionName` for Android. While the optional build number, `{build_number}`, sets `CFBundleVersion` for iOS and `versionCode` for Android. 

With flutter build commands these values can be overridden with the command line arguments --build-name and --build-number or by setting the environment variables FLUTTER_BUILD_NAME and FLUTTER_BUILD_NUMBER.

```xml
<key>CFBundlePackageType</key>
	<string>APPL</string>
	<key>CFBundleShortVersionString</key>
	<string>$(FLUTTER_BUILD_NAME)</string>
```

# Task
Set the `--build-number` for the flutter build command with CodeMagic env [BUILD_NUMBER](https://docs.codemagic.io/knowledge-codemagic/build-versioning/#environment-variables)