### PR TITLE
Get the latest version of the testflight from app store

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -11,7 +11,9 @@ workflows:
       xcode: 14.3
       cocoapods: default
     cache:
-      cache_paths: [ ]
+      cache_paths:
+        - $FLUTTER_ROOT/.pub-cache          # Dart cache
+        - $HOME/Library/Caches/CocoaPods    # CocoaPods cache
     triggering:
       events:
         # publish only tagged commits to main:
@@ -21,29 +23,18 @@ workflows:
           include: true
           source: false
     scripts:
-      #      - name: Get the latest build number
-      #        script: |
-      #          # Get the latest testflight build number
-      #          LATEST_TESTFLIGHT_BUILD_NUMBER=$(app-store-connect get-latest-testflight-build-number "$APP_APPLE_ID")
-      #          # avgtool must run in the folder where xcodeproj file is located
-      #          cd ./ios
-      #          # Increment the latest testflight build number by 1
-      #          NEW_BUILD_NUMBER=$((LATEST_TESTFLIGHT_BUILD_NUMBER + 1))
-      #          # Update the build number using agvtool
-      #          agvtool new-version -all $NEW_BUILD_NUMBER
-      #          cd $CM_BUILD_DIR
-
-      #          LATEST_BUILD_NUMBER=$(app-store-connect get-latest-app-store-build-number "$APP_APPLE_ID")
-      #          agvtool new-version -all $(($(app-store-connect get-latest-testflight-build-number "$TOD_APPLE_ID") + 1))
-      - name: Get the latest build number
+      - &increment_testflight_build_number
+        name: Get the latest build number
         script: |
-          LATEST_BUILD_NUMBER=$(app-store-connect get-latest-testflight-build-number $APP_APPLE_ID)
+          LATEST_BUILD_NUMBER=$(app-store-connect get-latest-testflight-build-number $APP_APPLE_ID --pre-release-version 0.0.2)
           cd ./ios # avgtool must run in the folder where xcodeproj file is located, to edit the xcconfig file
           agvtool new-version -all $(($LATEST_BUILD_NUMBER + 1)) 
-          BUILD_NUMBER=$(($(app-store-connect get-latest-testflight-build-number $APP_APPLE_ID) + 1))
-          cd $CM_BUILD_DIR
+          BUILD_NUMBER=$(($(app-store-connect get-latest-testflight-build-number $APP_APPLE_ID --pre-release-version 0.0.2) + 1))
+          #!/bin/sh
+          set -ex
+          printenv
         ignore_failure: false
-      - name: Set up app/build.gradle
+      - name: Print the environmental variables
         script: |
           #!/bin/sh
           set -ex
@@ -87,6 +78,7 @@ workflows:
           include: true
           source: false
     scripts:
+      - *increment_testflight_build_number
       - echo $GOOGLE_PLAY_JSON | base64 --decode > google_play.json
       - bundle install
       - bundle exec fastlane setup_keychain

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -5,6 +5,7 @@ workflows:
     environment:
       groups:
         - app_store
+        - app_store_credentials
         - match
       flutter: 3.7.12
       xcode: 14.3
@@ -20,6 +21,33 @@ workflows:
           include: true
           source: false
     scripts:
+      #      - name: Get the latest build number
+      #        script: |
+      #          # Get the latest testflight build number
+      #          LATEST_TESTFLIGHT_BUILD_NUMBER=$(app-store-connect get-latest-testflight-build-number "$APP_APPLE_ID")
+      #          # avgtool must run in the folder where xcodeproj file is located
+      #          cd ./ios
+      #          # Increment the latest testflight build number by 1
+      #          NEW_BUILD_NUMBER=$((LATEST_TESTFLIGHT_BUILD_NUMBER + 1))
+      #          # Update the build number using agvtool
+      #          agvtool new-version -all $NEW_BUILD_NUMBER
+      #          cd $CM_BUILD_DIR
+
+      #          LATEST_BUILD_NUMBER=$(app-store-connect get-latest-app-store-build-number "$APP_APPLE_ID")
+      #          agvtool new-version -all $(($(app-store-connect get-latest-testflight-build-number "$TOD_APPLE_ID") + 1))
+      - name: Get the latest build number
+        script: |
+          LATEST_BUILD_NUMBER=$(app-store-connect get-latest-testflight-build-number $APP_APPLE_ID)
+          cd ./ios # avgtool must run in the folder where xcodeproj file is located, to edit the xcconfig file
+          agvtool new-version -all $(($LATEST_BUILD_NUMBER + 1)) 
+          BUILD_NUMBER=$(($(app-store-connect get-latest-testflight-build-number $APP_APPLE_ID) + 1))
+          cd $CM_BUILD_DIR
+        ignore_failure: false
+      - name: Set up app/build.gradle
+        script: |
+          #!/bin/sh
+          set -ex
+          printenv
       - name: Build iOS app
         script: |
           bundle install
@@ -42,6 +70,7 @@ workflows:
       groups:
         - match
         - app_store
+        - app_store_credentials
         - google_play
         - keystore_credentials
       flutter: 3.7.12

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,8 +74,8 @@ fastlane renew_profile
 
   desc 'Builds an appstore version of the application and distributes to AppStore Connect'
   lane :deploy do
-    BUILD_NUMBER = ENV['BUILD_NUMBER'].to_s
     common_build_actions()
+    BUILD_NUMBER = ENV['BUILD_NUMBER'].to_s
     Dir.chdir ".." do
       sh("flutter", "build", "ios", "--release", "--no-codesign", "--build-number=#{BUILD_NUMBER}")
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -75,9 +75,8 @@ fastlane renew_profile
   desc 'Builds an appstore version of the application and distributes to AppStore Connect'
   lane :deploy do
     common_build_actions()
-    BUILD_NUMBER = ENV['BUILD_NUMBER'].to_s
     Dir.chdir ".." do
-      sh("flutter", "build", "ios", "--release", "--no-codesign", "--build-number=#{BUILD_NUMBER}")
+      sh("flutter", "build", "ios", "--release", "--no-codesign")
     end
 
     match(app_identifier: 'com.ripplearc.composerandomwords', type: 'appstore', keychain_password: 'secretPass', readonly: RUNNING_ON_CI)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # For more information, check out Version your app in the Android documentation.
 # Override: BUILD_NUMBER=[#] bundle exec fastlane android deploy
 # https://blog.codemagic.io/ci-cd-for-flutter-with-fastlane-codemagic/#first-upload
-version: 0.0.2+3
+version: 0.0.3+3
 
 environment:
   sdk: '>=2.19.4 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # For more information, check out Version your app in the Android documentation.
 # Override: BUILD_NUMBER=[#] bundle exec fastlane android deploy
 # https://blog.codemagic.io/ci-cd-for-flutter-with-fastlane-codemagic/#first-upload
-version: 0.0.3+3
+version: 0.0.2+3
 
 environment:
   sdk: '>=2.19.4 <4.0.0'


### PR DESCRIPTION
## Context

iOS build number must monotonically increase in a build version. We need to query the Testflight and get the latest build number.

## Tasks
- Get the latest Testflight build number using CodeMagic's `app-store-connect` and alter the build number in the xcodeproj using `agvtool`

## Links
[Automatic build versioning](https://docs.codemagic.io/knowledge-codemagic/build-versioning/)
[get-latest-testflight-build-number](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/app-store-connect/get-latest-testflight-build-number.md)

<img width="1680" alt="Screenshot 2023-06-21 at 10 17 19 AM" src="https://github.com/ripplearc/flutter-state-management/assets/2512248/cb4b0d89-3479-4d8a-b073-a2d33e4ba383">
