### PR TITLE
Android latest version number

### DIFF
--- a/ci/build_android_qa.sh
+++ b/ci/build_android_qa.sh
@@ -6,4 +6,5 @@
 # If you use a specific number locally, a build with the same number will fail on Codemagic.
 # For BUILD_NUMBER (VersionCode) see
 # https://docs.flutter.dev/deployment/android#updating-the-apps-version-number
-bundle exec fastlane android deploy
+build_number="$1"  # Store the value of the first command-line argument
+bundle exec fastlane android deploy build_number:13 build_number:"$build_number"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -58,8 +58,6 @@ workflows:
         - google_play
         - keystore_credentials
       flutter: 3.7.12
-      xcode: 14.3
-      cocoapods: default
     cache:
       cache_paths: [ ]
     triggering:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -34,12 +34,8 @@ workflows:
           set -ex
           printenv
         ignore_failure: false
-      - name: Print the environmental variables
-        script: |
-          #!/bin/sh
-          set -ex
-          printenv
-      - name: Build iOS app
+      - &build_ios_app
+        name: Build iOS app
         script: |
           bundle install
           bundle exec fastlane setup_keychain
@@ -48,6 +44,51 @@ workflows:
     artifacts:
       - build/ios/ipa/*.ipa
       - ./*.ipa
+      - /tmp/xcodebuild_logs/*.log
+      - flutter_drive.log
+    publishing:
+      email:
+        recipients:
+          - ripplearc@gmail.com
+  publish-qa-android:
+    name: Publish Android QA
+    max_build_duration: 60
+    environment:
+      groups:
+        - google_play
+        - keystore_credentials
+      flutter: 3.7.12
+      xcode: 14.3
+      cocoapods: default
+    cache:
+      cache_paths: [ ]
+    triggering:
+      events:
+        # publish only tagged commits to main:
+        - tag
+      branch_patterns:
+        - pattern: main
+          include: true
+          source: false
+    scripts:
+      - &set_up_key_store_and_properties
+        name: Set up release keystore, key.properties, local.properties
+        script: |
+          echo $GOOGLE_PLAY_JSON | base64 --decode > google_play.json
+          echo $ANDROID_KEYSTORE | base64 --decode > "$FCI_BUILD_DIR/android/app/randomword-release.keystore"
+          echo $ANDROID_KEY_PROPERTIES | base64 --decode > "$FCI_BUILD_DIR/android/key.properties"
+          echo "flutter.sdk=$HOME/programs/flutter" > "$FCI_BUILD_DIR/android/local.properties"
+      - &increment_google_play_build_number_and_build_android_app
+        name: Build the release app with the latest build number from Google Play
+        script: |
+          LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name 'com.ripplearc.composerandomwords' --verbose)
+          echo INCREMENT_GOOGLE_PLAY_BUILD_NUMBER: $INCREMENT_GOOGLE_PLAY_BUILD_NUMBER
+          bundle install
+          bundle exec fastlane android deploy build_number:$((LATEST_GOOGLE_PLAY_BUILD_NUMBER+1))
+    artifacts:
+      - build/**/outputs/**/*.apk
+      - build/**/outputs/**/*.aab
+      - build/**/outputs/**/mapping.txt
       - /tmp/xcodebuild_logs/*.log
       - flutter_drive.log
     publishing:
@@ -78,20 +119,10 @@ workflows:
           include: true
           source: false
     scripts:
+      - *set_up_key_store_and_properties
+      - *increment_google_play_build_number_and_build_android_app
       - *increment_testflight_build_number
-      - echo $GOOGLE_PLAY_JSON | base64 --decode > google_play.json
-      - bundle install
-      - bundle exec fastlane setup_keychain
-      - |
-        # set up release keystore & key.properties
-        echo $ANDROID_KEYSTORE | base64 --decode > "$FCI_BUILD_DIR/android/app/randomword-release.keystore"
-        echo $ANDROID_KEY_PROPERTIES | base64 --decode > "$FCI_BUILD_DIR/android/key.properties"
-      - |
-        # set up local properties
-        echo "flutter.sdk=$HOME/programs/flutter" > "$FCI_BUILD_DIR/android/local.properties"
-      - sh ci/build_android_qa.sh
-      - find . -name "Podfile" -execdir pod install \;
-      - sh ci/build_ios_qa.sh
+      - *build_ios_app
     artifacts:
       - build/**/outputs/**/*.apk
       - build/**/outputs/**/*.aab

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,13 +98,19 @@ fastlane renew_profile
   end
 end
 
+
 platform :android do
   desc 'Builds and signs a production release to distribute in Google Play Store'
-  lane :deploy do
-    BUILD_NUMBER = ENV['BUILD_NUMBER'].to_s
+# pass in parameter of build_number here
+  lane :deploy do |options|
+    build_number = options[:build_number] || ENV['BUILD_NUMBER'].to_s
     common_build_actions()
     Dir.chdir ".." do
-      sh("flutter", "build", "appbundle", "--build-number=#{BUILD_NUMBER}")
+#       sh("LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name 'com.ripplearc.composerandomwords' --verbose) \
+#           && INCREMENT_GOOGLE_PLAY_BUILD_NUMBER=$((LATEST_GOOGLE_PLAY_BUILD_NUMBER+1)) \
+#           && echo INCREMENT_GOOGLE_PLAY_BUILD_NUMBER: $INCREMENT_GOOGLE_PLAY_BUILD_NUMBER \
+#           && flutter build appbundle --build-number=$INCREMENT_GOOGLE_PLAY_BUILD_NUMBER")
+      sh("flutter build appbundle --build-number=#{build_number}")
     end
 
     supply(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -101,15 +101,10 @@ end
 
 platform :android do
   desc 'Builds and signs a production release to distribute in Google Play Store'
-# pass in parameter of build_number here
   lane :deploy do |options|
     build_number = options[:build_number] || ENV['BUILD_NUMBER'].to_s
     common_build_actions()
     Dir.chdir ".." do
-#       sh("LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name 'com.ripplearc.composerandomwords' --verbose) \
-#           && INCREMENT_GOOGLE_PLAY_BUILD_NUMBER=$((LATEST_GOOGLE_PLAY_BUILD_NUMBER+1)) \
-#           && echo INCREMENT_GOOGLE_PLAY_BUILD_NUMBER: $INCREMENT_GOOGLE_PLAY_BUILD_NUMBER \
-#           && flutter build appbundle --build-number=$INCREMENT_GOOGLE_PLAY_BUILD_NUMBER")
       sh("flutter build appbundle --build-number=#{build_number}")
     end
 


### PR DESCRIPTION
# Context
Google play requires monolithic increase of the version code (Flutter build number) of the apk. We need to query the Google Play to find the latest version code of the app and increment it.

# Tasks
- Get and increment the latest version code of the app using CodeMagic's `get-latest-build-number`
- Pass the incremented version code as Flutter build number to the android deploy lane 