### PR TITLE
Add CodeMagic workflow for iOS integration tests

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -133,8 +133,8 @@ workflows:
       email:
         recipients:
           - ripplearc@gmail.com
-  pr:
-    name: PR Tests
+  unit-and-widget-tests:
+    name: Unit & Widget Tests
     max_build_duration: 60
     environment:
       flutter: 3.7.12
@@ -154,15 +154,44 @@ workflows:
       - |
         # set up local properties
         echo "flutter.sdk=$HOME/programs/flutter" > "$FCI_BUILD_DIR/android/local.properties"
-### How to trigger the UI tests
-### How to run code coverage?
+      ### How to trigger the UI tests
+      ### How to run code coverage?
       - &run_unit_tests
         name: Run unit and widget tests
         script: |
           mkdir -p test-results
           bundle install
-          bundle exec fastlane run_unit_widget_tests
+          bundle exec fastlane run_unit_widget_tests test_report_path:test-results/unit_tests.json
         test_report: test-results/unit_tests.json
+    publishing:
+      email:
+        recipients:
+          - ripplearc@gmail.com
+  integration-tests:
+    name: iOS and Web Integration Tests
+    max_build_duration: 60
+    environment:
+      flutter: 3.7.12
+      xcode: 14.3
+      cocoapods: default
+    cache:
+      cache_paths: [ ]
+    triggering:
+      events:
+        # test each PR to main:
+        - pull_request
+      branch_patterns:
+        - pattern: main
+          include: true
+          source: false
+    scripts:
+      - &run_ios_integration_tests
+        name: Flutter integration tests (iOS)
+        script: |
+          mkdir -p test-results
+          bundle install
+          bundle exec fastlane run_ios_integration_tests test_report_path:test-results/integration_tests.json
+        test_report: test-results/integration_tests.json
     publishing:
       email:
         recipients:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,11 +16,24 @@ def common_build_actions()
   end
 end
 
-lane :run_unit_widget_tests do
+lane :run_unit_widget_tests do |options|
+  test_report_path = options[:test_report_path]
   # Execute Flutter unit tests
   common_build_actions()
   Dir.chdir ".." do
-    sh("flutter test --machine > test-results/unit_tests.json")
+    sh("flutter test --machine > #{test_report_path}")
+  end
+end
+
+lane :run_ios_integration_tests do |options|
+  test_report_path = options[:test_report_path]
+  # Execute Flutter integration tests
+  common_build_actions()
+  Dir.chdir ".." do
+    sh("xcrun simctl shutdown all \
+        && TEST_DEVICE=$(xcrun simctl create test-device com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-16-4) \
+        && xcrun simctl boot $TEST_DEVICE \
+        && flutter -d $TEST_DEVICE test integration_test --machine > #{test_report_path}")
   end
 end
 

--- a/test_driver/integration_driver.dart
+++ b/test_driver/integration_driver.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
# Context
Integration tests are much more expensive, time and dollar wise, to run. We should only run it when the developer is ready with the coding and unit/widget tests work. 

# Tasks
- Create CodeMagic workflow to run the iOS integration tests
- Only run the iOS integration tests when adding a label of `run-integration-tests`