### PR TITLE
Run flutter drive on a customized port

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -200,12 +200,12 @@ workflows:
         name: Flutter integration tests (Chrome)
         script: |
           bundle install
-          bundle exec fastlane run_web_chrome_integration_tests
+          bundle exec fastlane run_web_chrome_integration_tests port:4444
       - &run_web_safari_integration_tests
         name: Flutter integration tests (Safari)
         script: |
           bundle install
-          bundle exec fastlane run_web_safari_integration_tests
+          bundle exec fastlane run_web_safari_integration_tests port:5555
     publishing:
       email:
         recipients:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,10 +19,7 @@ end
 def close_driver_port(port)
   command = <<~BASH
     if nc -z localhost #{port}; then
-      pid=$(lsof -i :#{port} -t)
-      if [[ -n "$pid" ]]; then
-        kill "$pid" -9
-      fi
+       sudo kill -9 $(lsof -t -i :#{port})
     fi
   BASH
 
@@ -51,23 +48,25 @@ lane :run_ios_integration_tests do |options|
   end
 end
 
-lane :run_web_chrome_integration_tests do
+lane :run_web_chrome_integration_tests do |options|
+  port_number = options[:port]
   # Execute Chrome integration tests
   common_build_actions()
+  close_driver_port(port_number)
   Dir.chdir ".." do
     sh("brew upgrade --cask chromedriver \
         && chromedriver --version")
-    Process.spawn("chromedriver --port=4444 &")
+    Process.spawn("chromedriver --port=#{port_number} &")
     sh("flutter config --enable-web \
         && flutter drive \
            --driver=test_driver/integration_driver.dart \
            --target=integration_test/app_test.dart \
-           -d web-server --release --browser-name chrome")
+           -d web-server --driver-port=#{port_number} --release --browser-name chrome")
   end
 end
 
-lane :run_web_safari_integration_tests do
-  port_number = 4444
+lane :run_web_safari_integration_tests do |options|
+  port_number = options[:port]
   # Execute Chrome integration tests
   common_build_actions()
   close_driver_port(port_number)
@@ -78,7 +77,7 @@ lane :run_web_safari_integration_tests do
         && flutter drive \
            --driver=test_driver/integration_driver.dart \
            --target=integration_test/app_test.dart \
-           -d web-server --release --browser-name safari")
+           -d web-server --driver-port=#{port_number} --release --browser-name safari")
   end
 end
 


### PR DESCRIPTION
# Context
Previously, neither could we kill the safari driver, nor could we separate the port for safari driver and driver. Both chrome driver and safari driver run on the same ports, and we chrome integration tests must run before the safari tests. 

# Tasks
- Kill the safari driver reliably with `sudo`
- Specify the [driver-port](https://fig.io/manual/flutter/drive) when running flutter drive