### PR TITLE
Upload test coverage to codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ To run test coverage, try the following:
 flutter test --coverage; genhtml coverage/lcov.info -o coverage/html; open coverage/html/index.html
 ```
 
+
+## Test Coverage
+
+[![codecov badge](https://codecov.io/gh/ripplearc/flutter-state-management/branch/main/graph/badge.svg?token=${{secrets.CODECOV_TOKEN}})](https://codecov.io/gh/ripplearc/flutter-state-management)
+
+[![codecov badge](https://codecov.io/gh/ripplearc/flutter-state-management/branch/main/graphs/tree.svg?token=${{secrets.CODECOV_TOKEN}}))](https://codecov.io/gh/ripplearc/flutter-state-management)
+
+
+
 ## Widget and Integration Tests
 Widget and Integration tests are another essential part of app development. In this project, we show how to write Widget and Integration tests for the `BloC` approach.
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -139,6 +139,7 @@ workflows:
     environment:
       groups:
         - codecov
+        - codecov_credentials
       flutter: 3.7.12
       xcode: 14.3
       cocoapods: default
@@ -161,7 +162,12 @@ workflows:
         script: |
           mkdir -p test-results
           bundle install
-          bundle exec fastlane run_unit_widget_tests test_report_path:test-results/unit_tests.json code_coverage_target:$CODE_COVERAGE_TARGET incremental_code_coverage_target:$INCREMENTAL_CODE_COVERAGE_TARGET lcov_info_path:coverage/lcov.info
+          bundle exec fastlane run_unit_widget_tests \
+            test_report_path:test-results/unit_tests.json \
+            code_coverage_target:$CODE_COVERAGE_TARGET \
+            codecov_token:$CODECOV_TOKEN \
+            incremental_code_coverage_target:$INCREMENTAL_CODE_COVERAGE_TARGET \
+            lcov_info_path:coverage/lcov.info
         test_report: test-results/unit_tests.json
     publishing:
       email:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -81,6 +81,12 @@ def check_incremental_code_coverage(incremental_code_coverage_target, lcov_info_
   end
 end
 
+def upload_coverage_to_codecov(codecov_token)
+  sh("curl -Os https://uploader.codecov.io/latest/macos/codecov")
+  sh("chmod +x codecov")
+  sh("./codecov -t #{codecov_token}")
+end
+
 lane :run_unit_widget_tests do |options|
   test_report_path = options[:test_report_path]
 
@@ -95,6 +101,7 @@ lane :run_unit_widget_tests do |options|
 
   check_overall_code_coverage(code_coverage_target, lcov_info_path)
   check_incremental_code_coverage(incremental_code_coverage_target, lcov_info_path)
+  upload_coverage_to_codecov(options[:codecov_token])
 
 end
 

--- a/lib/generator_page.dart
+++ b/lib/generator_page.dart
@@ -77,7 +77,9 @@ class _GeneratorPageState extends State<GeneratorPage> {
 /// random word from the user's [RandomWordState.favorites].
 class FavoriteButton extends StatelessWidget {
   const FavoriteButton(
-      {super.key, required this.onPress, required this.isFavorite});
+      {super.key,
+        required this.onPress,
+        required this.isFavorite});
 
 
   final VoidCallback onPress;


### PR DESCRIPTION
# Context

Upload test coverage results to the CodeCov will allow developers to see coverage information in the GitHub checks

# Task
- Upload test coverage results to CodeCov

# Reference
[CodeCov integration with GitHub](https://docs.codecov.com/docs)
[CodeCov integration with CodeMagic](https://docs.codemagic.io/integrations/codecov-integration/)
[line-by-line coverage via GitHub Checks](https://about.codecov.io/blog/announcing-line-by-line-coverage-via-github-checks/#:~:text=On%20a%20pull%20request%2C%20simply,right%20side%20of%20the%20annotation)