### PR TITLE
Submit immediately upon upload

### DIFF
--- a/fastlane/lanes/ReleaseLanes.rb
+++ b/fastlane/lanes/ReleaseLanes.rb
@@ -85,7 +85,7 @@ platform :ios do
     pilot(
       username: APPLE_ID,
       team_id: '120815547',
-      skip_submission: true,
+      skip_submission: false,
       skip_waiting_for_build_processing: true,
       apple_id: '6449834100'
     )

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,5 +47,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # For more information, check out Version your app in the Android documentation.
 # Override: BUILD_NUMBER=[#] bundle exec fastlane android deploy
 # https://blog.codemagic.io/ci-cd-for-flutter-with-fastlane-codemagic/#first-upload
-version: 0.0.2+3
+version: 0.0.3+3
 
 environment:
   sdk: '>=2.19.4 <4.0.0'


### PR DESCRIPTION
# Context

We are scheduling automatic daily/nightly iOS builds and currently we need to manually submit and confirm encryption exemption after the upload

# Tasks

- set `skip_submission` to  `true` in the Fastlane `pilot` lane: This parameter, when set to true, indicates that the build should be uploaded to App Store Connect but not automatically submitted for review. This can be useful if you want to manually review and submit the build later.
- set `ITSAppUsesNonExemptEncryption` to `true` in the `infolist`: Unless your app is using some special encryption you can simply add Boolean a key to your Info.plist with name [ITSAppUsesNonExemptEncryption and value false](https://medium.com/@iamCoder/how-to-solve-missing-compliance-status-in-testflight-and-invites-not-coming-to-testers-4cbbe3c4ed12)