### PR TITLE
Upload the debug symbol/mapping file to the Google Play

### DIFF
--- a/fastlane/lanes/ReleaseLanes.rb
+++ b/fastlane/lanes/ReleaseLanes.rb
@@ -103,8 +103,9 @@ platform :android do
 
     supply(
       aab: 'build/app/outputs/bundle/release/app-release.aab',
+      mapping: 'build/app/outputs/mapping/release/mapping.txt',
       json_key: 'google_play.json',
-      release_status: 'draft',
+      release_status: 'completed',
       track: 'internal',
       skip_upload_metadata: true,
       skip_upload_images: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.4.0
+  golden_toolkit: ^0.15.0
 
   flutter_lints: ^2.0.0
   bloc_test: ^9.1.1


### PR DESCRIPTION
# Context
To see the unobfuscated crash logs in the Google Play, the mapping file must be uploaded alongside the build

# Tasks
- Upload the mapping file in the supply function